### PR TITLE
Match draw

### DIFF
--- a/tournament/tournament.py
+++ b/tournament/tournament.py
@@ -89,7 +89,8 @@ def playerStandings():
                         'LEFT JOIN matches '
                         'ON players.id = matches.loser_id '
                         'GROUP BY players.id;')
-    total_matches_sql = ('SELECT games_won.id, games_won.name, '
+    total_matches_sql = ('CREATE OR REPLACE VIEW total_matches AS '
+                         'SELECT games_won.id, games_won.name, '
                          'games_won.wins, (SELECT COALESCE(games_won.wins) + ' 
                          'COALESCE(games_lost.losses) AS matches) '
                          'FROM games_won JOIN games_lost '
@@ -98,6 +99,7 @@ def playerStandings():
     c.execute(matches_won_sql)
     c.execute(matches_lost_sql)
     c.execute(total_matches_sql)
+    c.execute('SELECT * FROM total_matches;')
     results = c.fetchall()
     db.commit()
     db.close()

--- a/tournament/tournament.py
+++ b/tournament/tournament.py
@@ -89,15 +89,31 @@ def playerStandings():
                         'LEFT JOIN matches '
                         'ON players.id = matches.loser_id '
                         'GROUP BY players.id;')
+    matches_draw_sql = ('CREATE OR REPLACE VIEW games_draw AS '
+                        'SELECT players.id, players.name, '
+                        'COUNT(matches.match_id) AS draws '
+                        'FROM players '
+                        'LEFT JOIN matches '
+                        'ON players.id = matches.draw_id_one '
+                        'OR players.id = matches.draw_id_two '
+                        'GROUP BY players.id;')
     total_matches_sql = ('CREATE OR REPLACE VIEW total_matches AS '
                          'SELECT games_won.id, games_won.name, '
-                         'games_won.wins, (SELECT COALESCE(games_won.wins) + ' 
-                         'COALESCE(games_lost.losses) AS matches) '
-                         'FROM games_won JOIN games_lost '
-                         'ON games_won.id = games_lost.id '
-                         'ORDER BY games_won.wins DESC;')
+                         'games_won.wins, games_lost.losses, '
+                         'games_draw.draws, '
+                         '(SELECT COALESCE(games_won.wins) + ' 
+                         'COALESCE(games_lost.losses) + '
+                         'COALESCE(games_draw.draws) AS matches) '
+                         'FROM games_won '
+                         'JOIN games_draw '
+                         'ON games_draw.id = games_won.id '
+                         'JOIN games_lost '
+                         'ON games_lost.id = games_draw.id '
+                         'ORDER BY games_won.wins DESC, '
+                         'games_draw.draws DESC;')
     c.execute(matches_won_sql)
     c.execute(matches_lost_sql)
+    c.execute(matches_draw_sql)
     c.execute(total_matches_sql)
     c.execute('SELECT * FROM total_matches;')
     results = c.fetchall()
@@ -107,7 +123,7 @@ def playerStandings():
     return results
 
 
-def reportMatch(winner, loser):
+def reportMatch(winner, loser, draw=False):
     """Records the outcome of a single match between two players.
 
     Args:
@@ -116,7 +132,10 @@ def reportMatch(winner, loser):
     """
     db = connect('tournament')
     c = db.cursor()
-    c.execute("INSERT INTO matches (winner_id, loser_id) VALUES (%s, %s);", (winner, loser,))
+    if draw:
+        c.execute("INSERT INTO matches (draw_id_one, draw_id_two) VALUES (%s, %s);", (winner, loser,))
+    else:
+        c.execute("INSERT INTO matches (winner_id, loser_id) VALUES (%s, %s);", (winner, loser,))
     db.commit()
     db.close()
 

--- a/tournament/tournament.sql
+++ b/tournament/tournament.sql
@@ -13,12 +13,13 @@ CREATE DATABASE tournament;
 -- Create tables
 CREATE TABLE players (
 	id serial PRIMARY KEY,
-	name text,
-	wins integer,
-	losses integer);
+	name text);
 
 CREATE TABLE matches (
 	match_id serial PRIMARY KEY,
 	winner_id integer REFERENCES players (id),
-	loser_id integer REFERENCES players (id));
+	loser_id integer REFERENCES players (id),
+	draw_id_one integer REFERENCES players (id),
+	draw_id_two integer REFERENCES players (id),
+	);
 	

--- a/tournament/tournament.sql
+++ b/tournament/tournament.sql
@@ -20,6 +20,5 @@ CREATE TABLE matches (
 	winner_id integer REFERENCES players (id),
 	loser_id integer REFERENCES players (id),
 	draw_id_one integer REFERENCES players (id),
-	draw_id_two integer REFERENCES players (id),
-	);
+	draw_id_two integer REFERENCES players (id));
 	

--- a/tournament/tournament_test.py
+++ b/tournament/tournament_test.py
@@ -67,9 +67,9 @@ def testStandingsBeforeMatches():
                          "they have played any matches.")
     elif len(standings) > 2:
         raise ValueError("Only registered players should appear in standings.")
-    if len(standings[0]) != 4:
-        raise ValueError("Each playerStandings row should have four columns.")
-    [(id1, name1, wins1, matches1), (id2, name2, wins2, matches2)] = standings
+    if len(standings[0]) != 6:
+        raise ValueError("Each playerStandings row should have six columns.")
+    [(id1, name1, wins1, losses1, draws1, matches1), (id2, name2, wins2, losses1, draws2, matches2)] = standings
     if matches1 != 0 or matches2 != 0 or wins1 != 0 or wins2 != 0:
         raise ValueError(
             "Newly registered players should have no matches or wins.")
@@ -91,7 +91,7 @@ def testReportMatches():
     reportMatch(id1, id2)
     reportMatch(id3, id4)
     standings = playerStandings()
-    for (i, n, w, m) in standings:
+    for (i, n, w, l, d, m) in standings:
         if m != 1:
             raise ValueError("Each player should have one match recorded.")
         if i in (id1, id3) and w != 1:
@@ -124,6 +124,24 @@ def testPairings():
             "After one match, players with one win should be paired.")
     print "8. After one match, players with one win are paired."
 
+def testMatchDraw():
+    deleteMatches()
+    deletePlayers()
+    registerPlayer("Twilight Sparkle")
+    registerPlayer("Fluttershy")
+    registerPlayer("Applejack")
+    registerPlayer("Pinkie Pie")
+    standings = playerStandings()
+    [id1, id2, id3, id4] = [row[0] for row in standings]
+    reportMatch(id1, id2)
+    reportMatch(id3, id4, draw=True)
+    standings = playerStandings()
+    for (i, n, w, l, d, m) in standings:
+        if (d) in (id3, id4) != 1:
+            raise ValueError(
+                "There should be two players with one draw each.")
+    print "9. A match between players can end in a draw."
+
 
 if __name__ == '__main__':
     testDeleteMatches()
@@ -134,6 +152,7 @@ if __name__ == '__main__':
     testStandingsBeforeMatches()
     testReportMatches()
     testPairings()
+    testMatchDraw()
     print "Success!  All tests pass!"
 
 


### PR DESCRIPTION
- Changed total_matches view to return two extra columns: losses and
  draws. It just didn’t make sense to omit them and make user infer how
  many losses/draws a player had by doing math.
- Tweaked reportMatches to accept ids for both players involved in draw
- Created two columns in matches to hold ids of tied players. I did
  this instead of a bool value to make the SQL queries a little easier
  and maintainable.
